### PR TITLE
dietgpu: add optional checksum and version number information (#16)

### DIFF
--- a/dietgpu/ans/ANSTest.cu
+++ b/dietgpu/ans/ANSTest.cu
@@ -118,7 +118,7 @@ void runBatchPointer(
 
   ansEncodeBatchPointer(
       res,
-      prec,
+      ANSCodecConfig(prec, true),
       numInBatch,
       inPtrs.data(),
       batchSizes.data(),
@@ -144,11 +144,10 @@ void runBatchPointer(
 
   auto outSuccess_dev = res.alloc<uint8_t>(stream, numInBatch);
   auto outSize_dev = res.alloc<uint32_t>(stream, numInBatch);
-  ;
 
   ansDecodeBatchPointer(
       res,
-      prec,
+      ANSCodecConfig(prec, true),
       numInBatch,
       (const void**)encPtrs.data(),
       decPtrs.data(),
@@ -189,7 +188,7 @@ void runBatchStride(
 
   ansEncodeBatchStride(
       res,
-      ANSCodecConfig(prec),
+      ANSCodecConfig(prec, true),
       numInBatch,
       orig_dev.data(),
       inBatchSize,
@@ -215,7 +214,7 @@ void runBatchStride(
   // sure the compressed size is accurate
   ansDecodeBatchStride(
       res,
-      ANSCodecConfig(prec),
+      ANSCodecConfig(prec, true),
       numInBatch,
       enc_dev.data(),
       outBatchStride,

--- a/dietgpu/ans/GpuANSDecode.cu
+++ b/dietgpu/ans/GpuANSDecode.cu
@@ -17,7 +17,7 @@
 
 namespace dietgpu {
 
-void ansDecodeBatchStride(
+ANSDecodeStatus ansDecodeBatchStride(
     StackDeviceMemory& res,
     const ANSCodecConfig& config,
     uint32_t numInBatch,
@@ -33,7 +33,7 @@ void ansDecodeBatchStride(
   auto outProvider =
       BatchProviderStride(out_dev, outPerBatchStride, outPerBatchCapacity);
 
-  ansDecodeBatch(
+  return ansDecodeBatch(
       res,
       config,
       numInBatch,
@@ -44,7 +44,7 @@ void ansDecodeBatchStride(
       stream);
 }
 
-void ansDecodeBatchPointer(
+ANSDecodeStatus ansDecodeBatchPointer(
     StackDeviceMemory& res,
     const ANSCodecConfig& config,
     uint32_t numInBatch,
@@ -64,7 +64,7 @@ void ansDecodeBatchPointer(
     auto outProvider = BatchProviderInlinePointerCapacity<kBSLimit>(
         numInBatch, out, outCapacity);
 
-    ansDecodeBatch(
+    return ansDecodeBatch(
         res,
         config,
         numInBatch,
@@ -73,7 +73,6 @@ void ansDecodeBatchPointer(
         outSuccess_dev,
         outSize_dev,
         stream);
-    return;
   }
 
   // Otherwise, we have to perform h2d copies
@@ -109,7 +108,7 @@ void ansDecodeBatchPointer(
   auto outProvider =
       BatchProviderPointer(out_dev.data(), outCapacity_dev.data());
 
-  ansDecodeBatch(
+  return ansDecodeBatch(
       res,
       config,
       numInBatch,
@@ -120,7 +119,7 @@ void ansDecodeBatchPointer(
       stream);
 }
 
-void ansDecodeBatchSplitSize(
+ANSDecodeStatus ansDecodeBatchSplitSize(
     StackDeviceMemory& res,
     const ANSCodecConfig& config,
     uint32_t numInBatch,
@@ -182,7 +181,7 @@ void ansDecodeBatchSplitSize(
       sizes_dev.data() + numInBatch,
       sizeof(uint8_t));
 
-  ansDecodeBatch(
+  return ansDecodeBatch(
       res,
       config,
       numInBatch,

--- a/dietgpu/ans/GpuANSInfo.cuh
+++ b/dietgpu/ans/GpuANSInfo.cuh
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "dietgpu/ans/GpuANSUtils.cuh"
+#include "dietgpu/utils/DeviceUtils.h"
+#include "dietgpu/utils/StackDeviceMemory.h"
+#include "dietgpu/utils/StaticUtils.h"
+
+namespace dietgpu {
+
+template <typename InProvider>
+__global__ void ansGetCompressedInfoKernel(
+    InProvider inProvider,
+    uint32_t numInBatch,
+    uint32_t* outSizes,
+    uint32_t* outChecksum) {
+  int batch = blockIdx.x * blockDim.x + threadIdx.x;
+  if (batch < numInBatch) {
+    auto header = (const ANSCoalescedHeader*)inProvider.getBatchStart(batch);
+    // Make sure it is valid
+    header->checkMagicAndVersion();
+
+    if (outSizes) {
+      outSizes[batch] = header->getTotalUncompressedWords();
+    }
+
+    if (outChecksum) {
+      assert(header->getUseChecksum());
+      outChecksum[batch] = header->getChecksum();
+    }
+  }
+}
+
+template <typename InProvider>
+void ansGetCompressedInfo(
+    InProvider& inProvider,
+    uint32_t numInBatch,
+    uint32_t* outSizes_dev,
+    uint32_t* outChecksum_dev,
+    cudaStream_t stream) {
+  if (!outSizes_dev && !outChecksum_dev) {
+    return;
+  }
+
+  auto block = 128;
+  auto grid = divUp(numInBatch, block);
+
+  ansGetCompressedInfoKernel<<<grid, block, 0, stream>>>(
+      inProvider, numInBatch, outSizes_dev, outChecksum_dev);
+
+  CUDA_TEST_ERROR();
+}
+
+} // namespace dietgpu

--- a/dietgpu/ans/GpuChecksum.cuh
+++ b/dietgpu/ans/GpuChecksum.cuh
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "dietgpu/utils/DeviceDefs.cuh"
+#include "dietgpu/utils/DeviceUtils.h"
+#include "dietgpu/utils/PtxUtils.cuh"
+#include "dietgpu/utils/StaticUtils.h"
+
+#include <cub/cub.cuh>
+
+namespace dietgpu {
+
+template <typename T>
+struct ReduceXor {
+  __host__ __device__ __forceinline__ T
+  operator()(const T& a, const T& b) const {
+    return a ^ b;
+  }
+};
+
+template <int Threads>
+__device__ void checksumSingle(
+    const uint8_t* __restrict__ in,
+    uint32_t size,
+    uint32_t* __restrict__ out) {
+  // FIXME: general presumption in dietgpu that input data for ANS is only byte
+  // aligned, while float data is only float word aligned, whereas ideally we
+  // would like a 32 bit checksum. Since there is ultimately no guarantee of
+  // anything but byte alignment and we wish to compute the same checksum
+  // regardless of memory placement, the only checksum that makes sense to
+  // produce is uint8.
+  // We can fix this to compute a full 32-bit checksum by keeping track of
+  // initial alignment and shuffling data around I think.
+  uint32_t checksum32 = 0;
+
+  // If the size of batch is smaller than the increment for alignment, we only
+  // handle the batch
+  auto roundUp4 = min(size, getAlignmentRoundUp<sizeof(uint4)>(in));
+
+  // The size of data that remains after alignment
+  auto remaining = size - roundUp4;
+
+  // The size of data (in uint4 words) that we can process with alignment
+  uint32_t numU4 = divDown(remaining, sizeof(uint4));
+
+  auto inAligned = in + roundUp4;
+  auto inAligned4 = (const uint4*)inAligned;
+
+  // Handle the non-aligned portion that we have to load as single bytes, if any
+  if (blockIdx.x == 0 && threadIdx.x < roundUp4) {
+    static_assert(sizeof(uint4) <= Threads, "");
+    checksum32 ^= in[threadIdx.x];
+  }
+
+  // Handle the portion that is aligned and uint4 vectorizable
+  // 37.60 us / 80.76% gmem / 51.29% smem for uint4 on A100
+  for (uint32_t i = blockIdx.x * Threads + threadIdx.x; i < numU4;
+       i += gridDim.x * Threads) {
+    uint4 v = inAligned4[i];
+
+    checksum32 ^= v.x;
+    checksum32 ^= v.y;
+    checksum32 ^= v.z;
+    checksum32 ^= v.w;
+  }
+
+  if (blockIdx.x == 0) {
+    // Handle the remainder portion that doesn't comprise full words
+    int i = numU4 * sizeof(uint4) + threadIdx.x;
+    if (i < remaining) {
+      checksum32 ^= inAligned[i];
+    }
+  }
+
+  // Fold the bytes of checksum32
+  checksum32 = (checksum32 & 0xffU) ^ ((checksum32 >> 8) & 0xffU) ^
+      ((checksum32 >> 16) & 0xffU) ^ ((checksum32 >> 24) & 0xffU);
+
+  // Reduce within a warp
+  using BlockReduce = cub::BlockReduce<uint32_t, Threads>;
+  __shared__ typename BlockReduce::TempStorage smem;
+
+  checksum32 = BlockReduce(smem).Reduce(checksum32, ReduceXor<uint32_t>());
+
+  if (threadIdx.x == 0) {
+    atomicXor(out, checksum32);
+  }
+}
+
+template <typename InProvider, int Threads>
+__global__ void checksumBatch(InProvider in, uint32_t* out) {
+  int batch = blockIdx.y;
+  out += batch;
+
+  checksumSingle<Threads>(
+      (const uint8_t*)in.getBatchStart(batch), in.getBatchSize(batch), out);
+}
+
+template <typename InProvider>
+void checksumBatch(
+    uint32_t numInBatch,
+    InProvider inProvider,
+    // size numInBatch
+    uint32_t* checksum_dev,
+    cudaStream_t stream) {
+  // zero out checksum before proceeding, as we aggregate with atomic xor
+  CUDA_VERIFY(
+      cudaMemsetAsync(checksum_dev, 0, sizeof(uint32_t) * numInBatch, stream));
+
+  constexpr uint32_t kThreads = 256;
+
+  // We unfortunately don't know the per-batch element sizes in advance
+  // What is the maximum number of blocks to saturate the GPU just in case some
+  // per-batch members are big?
+  int maxBlocks = 0;
+  CUDA_VERIFY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &maxBlocks, checksumBatch<InProvider, kThreads>, kThreads, 0));
+  maxBlocks *= getCurrentDeviceProperties().multiProcessorCount;
+
+  // The y block dimension will be for each batch element
+  uint32_t xBlocks = divUp(maxBlocks, numInBatch);
+  auto grid = dim3(xBlocks, numInBatch);
+
+  checksumBatch<InProvider, kThreads>
+      <<<grid, kThreads, 0, stream>>>(inProvider, checksum_dev);
+
+  CUDA_TEST_ERROR();
+}
+
+} // namespace dietgpu

--- a/dietgpu/ans_test.py
+++ b/dietgpu/ans_test.py
@@ -10,8 +10,8 @@ import torch
 torch.ops.load_library("//dietgpu:dietgpu")
 
 
-def run_test(dev, ts, temp_mem=None):
-    comp, sizes, _ = torch.ops.dietgpu.compress_data(False, ts, temp_mem)
+def run_test(dev, ts, checksum, temp_mem=None):
+    comp, sizes, _ = torch.ops.dietgpu.compress_data(False, ts, checksum, temp_mem)
     for s, t in zip(sizes, ts):
         t_bytes = t.numel() * t.element_size()
         print(
@@ -34,14 +34,14 @@ def run_test(dev, ts, temp_mem=None):
         out_sizes = torch.empty([len(ts)], dtype=torch.int32, device=dev)
 
         torch.ops.dietgpu.decompress_data(
-            False, truncated_comp, out_ts, temp_mem, out_status, out_sizes
+            False, truncated_comp, out_ts, checksum, temp_mem, out_status, out_sizes
         )
 
         for t, status, size in zip(ts, out_status, out_sizes):
             assert status.item()
             assert t.numel() * t.element_size() == size.item()
     else:
-        torch.ops.dietgpu.decompress_data(False, truncated_comp, out_ts)
+        torch.ops.dietgpu.decompress_data(False, truncated_comp, out_ts, checksum)
 
     for a, b in zip(ts, out_ts):
         assert torch.equal(a, b)
@@ -54,25 +54,26 @@ class TestANSCodec(unittest.TestCase):
 
         for dt in [torch.float32]:
             for tm in [False, True]:
-                ts = [
-                    torch.normal(0, 1.0, [10000], dtype=dt, device=dev),
-                    torch.normal(0, 1.0, [100000], dtype=dt, device=dev),
-                    torch.normal(0, 1.0, [1000000], dtype=dt, device=dev),
-                ]
-                if tm:
-                    run_test(dev, ts, temp_mem)
-                else:
-                    run_test(dev, ts)
+                for checksum in [False, True]:
+                    ts = [
+                        torch.normal(0, 1.0, [10000], dtype=dt, device=dev),
+                        torch.normal(0, 1.0, [100000], dtype=dt, device=dev),
+                        torch.normal(0, 1.0, [1000000], dtype=dt, device=dev),
+                    ]
+                    if tm:
+                        run_test(dev, ts, checksum, temp_mem)
+                    else:
+                        run_test(dev, ts, checksum)
 
     def test_empty(self):
         dev = torch.device("cuda:0")
         ts = [torch.empty([0], dtype=torch.uint8, device=dev)]
-        comp_ts = torch.ops.dietgpu.compress_data_simple(False, ts)
+        comp_ts = torch.ops.dietgpu.compress_data_simple(False, ts, True)
 
         # should have a header
         assert comp_ts[0].numel() > 0
 
-        decomp_ts = torch.ops.dietgpu.decompress_data_simple(False, comp_ts)
+        decomp_ts = torch.ops.dietgpu.decompress_data_simple(False, comp_ts, True)
         assert torch.equal(ts[0], decomp_ts[0])
 
     def test_split_compress(self):
@@ -100,9 +101,9 @@ class TestANSCodec(unittest.TestCase):
             splits = torch.split(t, sizes)
 
             comp_ts, _, _ = torch.ops.dietgpu.compress_data_split_size(
-                False, t, sizes_t, temp_mem
+                False, t, sizes_t, True, temp_mem
             )
-            decomp_ts = torch.ops.dietgpu.decompress_data_simple(False, comp_ts)
+            decomp_ts = torch.ops.dietgpu.decompress_data_simple(False, comp_ts, True)
 
             for orig, decomp in zip(splits, decomp_ts):
                 assert torch.equal(orig, decomp)
@@ -128,11 +129,11 @@ class TestANSCodec(unittest.TestCase):
             sizes_t = torch.IntTensor(sizes)
 
             splits = torch.split(t, sizes)
-            comp_ts = torch.ops.dietgpu.compress_data_simple(False, splits)
+            comp_ts = torch.ops.dietgpu.compress_data_simple(False, splits, True)
 
             decomp_t = torch.empty([sum_sizes], dtype=torch.uint8, device=dev)
             torch.ops.dietgpu.decompress_data_split_size(
-                False, comp_ts, decomp_t, sizes_t, temp_mem
+                False, comp_ts, decomp_t, sizes_t, True, temp_mem
             )
 
             assert torch.equal(t, decomp_t)

--- a/dietgpu/float/FloatTest.cu
+++ b/dietgpu/float/FloatTest.cu
@@ -162,7 +162,8 @@ void runBatchPointerTest(
 
   auto outBatchSize_dev = res.alloc<uint32_t>(stream, numInBatch);
 
-  auto compConfig = FloatCompressConfig(FT, probBits, false);
+  auto compConfig =
+      FloatCompressConfig(FT, ANSCodecConfig(probBits), false, true);
 
   floatCompress(
       res,
@@ -189,7 +190,8 @@ void runBatchPointerTest(
   auto outSuccess_dev = res.alloc<uint8_t>(stream, numInBatch);
   auto outSize_dev = res.alloc<uint32_t>(stream, numInBatch);
 
-  auto decompConfig = FloatDecompressConfig(FT, probBits, false);
+  auto decompConfig =
+      FloatDecompressConfig(FT, ANSCodecConfig(probBits), false, true);
 
   floatDecompress(
       res,

--- a/dietgpu/float/GpuFloatCompress.cu
+++ b/dietgpu/float/GpuFloatCompress.cu
@@ -27,13 +27,13 @@ uint32_t getMaxFloatCompressedSize(FloatType floatType, uint32_t size) {
   uint32_t baseSize = sizeof(GpuFloatHeader) + getMaxCompressedSize(size);
 
   switch (floatType) {
-    case kFloat16:
+    case FloatType::kFloat16:
       baseSize += FloatTypeInfo<FloatType::kFloat16>::getUncompDataSize(size);
       break;
-    case kBFloat16:
+    case FloatType::kBFloat16:
       baseSize += FloatTypeInfo<FloatType::kBFloat16>::getUncompDataSize(size);
       break;
-    case kFloat32:
+    case FloatType::kFloat32:
       baseSize += FloatTypeInfo<FloatType::kFloat32>::getUncompDataSize(size);
       break;
     default:

--- a/dietgpu/float/GpuFloatDecompress.cu
+++ b/dietgpu/float/GpuFloatDecompress.cu
@@ -19,7 +19,7 @@
 
 namespace dietgpu {
 
-void floatDecompress(
+FloatDecompressStatus floatDecompress(
     StackDeviceMemory& res,
     const FloatDecompressConfig& config,
     uint32_t numInBatch,
@@ -60,7 +60,7 @@ void floatDecompress(
     auto outProvider = BatchProviderInlinePointerCapacity<kLimit>(
         numInBatch, out, outCapacity);
 
-    floatDecompressDevice(
+    return floatDecompressDevice(
         res,
         updatedConfig,
         numInBatch,
@@ -70,8 +70,6 @@ void floatDecompress(
         outSuccess_dev,
         outSize_dev,
         stream);
-
-    return;
   }
 
   // Copy data to device
@@ -104,7 +102,7 @@ void floatDecompress(
   auto inProvider = BatchProviderPointer((void**)in_dev);
   auto outProvider = BatchProviderPointer((void**)out_dev, outCapacity_dev);
 
-  floatDecompressDevice(
+  return floatDecompressDevice(
       res,
       updatedConfig,
       numInBatch,
@@ -116,7 +114,7 @@ void floatDecompress(
       stream);
 }
 
-void floatDecompressSplitSize(
+FloatDecompressStatus floatDecompressSplitSize(
     StackDeviceMemory& res,
     const FloatDecompressConfig& config,
     uint32_t numInBatch,
@@ -168,7 +166,7 @@ void floatDecompressSplitSize(
   auto outProvider = BatchProviderSplitSize(
       out, sizes_dev.data(), sizes_dev.data() + numInBatch, floatWordSize);
 
-  floatDecompressDevice(
+  return floatDecompressDevice(
       res,
       updatedConfig,
       numInBatch,

--- a/dietgpu/float/GpuFloatInfo.cuh
+++ b/dietgpu/float/GpuFloatInfo.cuh
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <assert.h>
+#include "dietgpu/float/GpuFloatCodec.h"
+#include "dietgpu/float/GpuFloatUtils.cuh"
+#include "dietgpu/utils/DeviceUtils.h"
+#include "dietgpu/utils/StackDeviceMemory.h"
+#include "dietgpu/utils/StaticUtils.h"
+
+namespace dietgpu {
+
+template <typename InProvider>
+__global__ void floatGetCompressedInfoKernel(
+    InProvider inProvider,
+    uint32_t numInBatch,
+    uint32_t* outSizes,
+    uint32_t* outTypes,
+    uint32_t* outChecksum) {
+  int batch = blockIdx.x * blockDim.x + threadIdx.x;
+  if (batch < numInBatch) {
+    auto header = (const GpuFloatHeader*)inProvider.getBatchStart(batch);
+    header->checkMagicAndVersion();
+
+    if (outSizes) {
+      outSizes[batch] = header->size;
+    }
+    if (outTypes) {
+      outTypes[batch] = uint32_t(header->getFloatType());
+    }
+    if (outChecksum) {
+      assert(header->getUseChecksum());
+      outChecksum[batch] = header->getChecksum();
+    }
+  }
+}
+
+template <typename InProvider>
+void floatGetCompressedInfo(
+    InProvider& inProvider,
+    uint32_t numInBatch,
+    uint32_t* outSizes_dev,
+    uint32_t* outTypes_dev,
+    uint32_t* outChecksum_dev,
+    cudaStream_t stream) {
+  if (!outSizes_dev && !outTypes_dev && !outTypes_dev) {
+    return;
+  }
+
+  auto block = 128;
+  auto grid = divUp(numInBatch, block);
+
+  floatGetCompressedInfoKernel<<<grid, block, 0, stream>>>(
+      inProvider, numInBatch, outSizes_dev, outTypes_dev, outChecksum_dev);
+
+  CUDA_TEST_ERROR();
+}
+
+} // namespace dietgpu

--- a/dietgpu/float/GpuFloatUtils.cuh
+++ b/dietgpu/float/GpuFloatUtils.cuh
@@ -16,14 +16,59 @@
 
 namespace dietgpu {
 
-constexpr uint32_t kGpuFloatHeaderMagic = 0x1234f00d;
+// magic number to verify archive integrity
+constexpr uint32_t kFloatMagic = 0xf00f;
+
+// current DietGPU version number
+constexpr uint32_t kFloatVersion = 0x0001;
 
 // Header on our compressed floating point data
 struct __align__(16) GpuFloatHeader {
-  uint32_t magic;
+  __host__ __device__ void setMagicAndVersion() {
+    magicAndVersion = (kFloatMagic << 16) | kFloatVersion;
+  }
+
+  __host__ __device__ void checkMagicAndVersion() const {
+    assert((magicAndVersion >> 16) == kFloatMagic);
+    assert((magicAndVersion & 0xffffU) == kFloatVersion);
+  }
+
+  __host__ __device__ FloatType getFloatType() const {
+    return FloatType(options & 0xf);
+  }
+
+  __host__ __device__ void setFloatType(FloatType ft) {
+    assert(uint32_t(ft) <= 0xf);
+    options = (options & 0xfffffff0U) | uint32_t(ft);
+  }
+
+  __host__ __device__ bool getUseChecksum() const {
+    return options & 0x10;
+  }
+
+  __host__ __device__ void setUseChecksum(bool uc) {
+    options = (options & 0xffffffef) | (uint32_t(uc) << 4);
+  }
+
+  __host__ __device__ uint32_t getChecksum() const {
+    return checksum;
+  }
+
+  __host__ __device__ void setChecksum(uint32_t c) {
+    checksum = c;
+  }
+
+  // (16: magic)(16: version)
+  uint32_t magicAndVersion;
+
+  // Number of floating point words of the given float type in the archive
   uint32_t size;
-  uint32_t floatType;
-  uint32_t unused;
+
+  // (27: unused)(1: use checksum)(4: float type)
+  uint32_t options;
+
+  // Optional checksum computed on the input data
+  uint32_t checksum;
 };
 
 static_assert(sizeof(GpuFloatHeader) == 16, "");


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/dietgpu/pull/16

This diff adds two useful features for using DietGPU to store numeric data in persistent storage (e.g., for checkpointing large language model training purposes).

**1** This diff adds an optional feature to calculate a checksum of the data to be compressed which is stored in the archive, as well as an option to check the stored checksum against the decompressed data post-decompression. This is an additional check to safeguard the archival integrity of DietGPU.

All compress/decompress functions add an additional optional parameter to enable the checksum feature, which is the first optional parameter for all the functions.

There are two checksum flags, one for byte-wise ANS and one for the float compression. With float compression, the ANS flag cannot be used.

Computing and comparing the checksum adds another full pass to the data, so it is not recommended to use it for online, in-memory compression/decompression (e.g., shipping data over a network).

**2** A version number has been added to both the ANS and float data headers inside the archive. This will be used to safeguard against data format changes in subsequent iterations of DietGPU, in order to detect when a newer (or older) version of the library is being used to unpack an older (or newer, respectively) versioned archive.

A version mismatch will produce a CUDA kernel assert (as this is checked for all usages, especially with asynchronous ones where we wish to have as little d2h/h2d involvement with the CPU as possible), while a checksum mismatch error will itself be returned back to the CPU synchronously as an error status (C++), or from Python, will be thrown to Python as an error via `TORCH_CHECK`.

Also added a missing check that the float type in the archive expected upon decompression matches what is stored in the archive.

In order to add this feature, the data layout of the DietGPU archive has changed to include space for the checksum in the headers.

Issues / to do:
- the checksum at present is only 8 bits due to a (lack of) data alignment expectation, and is just a simple xor reduction at present. The ANS compressor can accept any input regardless of alignment (only byte alignment is required), while the float compressor expects float word-sized alignment (e.g., float16 requires 2 byte alignment). The checksum kernel ideally should compute a full uint32 checksum (if xor), or just use something like crc32.

Reviewed By: bwasti

Differential Revision: D41829599

fbshipit-source-id: c265eaa6efa39a3a94a4cc0e03714d994ab0ed5f